### PR TITLE
Reducing blazor size

### DIFF
--- a/SkyDocs.Blazor/SkyDocs.Blazor.csproj
+++ b/SkyDocs.Blazor/SkyDocs.Blazor.csproj
@@ -4,7 +4,9 @@
     <TargetFramework>net5.0</TargetFramework>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>CS8600;CS8601;CS8602;CS8603;CS8625;CS8613;CS8610</WarningsAsErrors>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
+    <BlazorEnableTimeZoneSupport>false</BlazorEnableTimeZoneSupport>
+    <BlazorWebAssemblyPreserveCollationData>false</BlazorWebAssemblyPreserveCollationData>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Original, 14.4 MB
https://eg0daf35c1792edctpugdm7vltvhjt1a8vi25ibtipqal02a3oghndo.siasky.net/

PR #5: 13.7 MB
https://eg05jndf4rn12s0lonjad1cfpdnhcdk37b40e7s5gfut2oao2tqe3co.siasky.net/
```
 <BlazorEnableTimeZoneSupport>false</BlazorEnableTimeZoneSupport>
    <BlazorWebAssemblyPreserveCollationData>false</BlazorWebAssemblyPreserveCollationData>
```

with ` <InvariantGlobalization>true</InvariantGlobalization>` it went to 12.5 MB

Removed Newtonsoft.Json, 11 MB:
https://cg0c9i9gsrerr07o1kf2lg3msn6bcm27ca2jqspft7drgdfc7k0953o.siasky.net/