### PR TITLE
No more newtonsoft.json, reducing file size

### DIFF
--- a/SkyDocs.Blazor/SkyDocs.Blazor.csproj
+++ b/SkyDocs.Blazor/SkyDocs.Blazor.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="HtmlAgilityPack" Version="1.11.33" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="Radzen.Blazor" Version="3.2.8" />
-    <PackageReference Include="SiaSkynet" Version="3.0.0" />
+    <PackageReference Include="SiaSkynet" Version="3.1.0-beta" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="5.0.5" PrivateAssets="all" />
     <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />


### PR DESCRIPTION
Original, 14.4 MB
https://eg0daf35c1792edctpugdm7vltvhjt1a8vi25ibtipqal02a3oghndo.siasky.net/

PR #5: 13.7 MB
https://eg05jndf4rn12s0lonjad1cfpdnhcdk37b40e7s5gfut2oao2tqe3co.siasky.net/
```
 <BlazorEnableTimeZoneSupport>false</BlazorEnableTimeZoneSupport>
    <BlazorWebAssemblyPreserveCollationData>false</BlazorWebAssemblyPreserveCollationData>
```

with ` <InvariantGlobalization>true</InvariantGlobalization>` it went to 12.5 MB

Removed Newtonsoft.Json, 11 MB:
https://cg0c9i9gsrerr07o1kf2lg3msn6bcm27ca2jqspft7drgdfc7k0953o.siasky.net/